### PR TITLE
Add uid to events

### DIFF
--- a/assets/javascripts/discourse/controllers/add-event.js.es6
+++ b/assets/javascripts/discourse/controllers/add-event.js.es6
@@ -179,7 +179,7 @@ export default Ember.Controller.extend({
         event = {
           timezone,
           all_day: allDay,
-          start: start.year(sYear).month(sMonth).date(sDate).hour(sHour).minute(sMin).toISOString()
+          start: start.year(sYear).month(sMonth).date(sDate).hour(sHour).minute(sMin).second(0).millisecond(0).toISOString()
         };
 
         const endEnabled = this.get('endEnabled');
@@ -195,7 +195,7 @@ export default Ember.Controller.extend({
           let eHour = allDay ? 0 : moment(endTime, 'HH:mm').hour();
           let eMin = allDay ? 0 : moment(endTime, 'HH:mm').minute();
 
-          event['end'] = end.year(eYear).month(eMonth).date(eDate).hour(eHour).minute(eMin).toISOString();
+          event['end'] = end.year(eYear).month(eMonth).date(eDate).hour(eHour).minute(eMin).second(0).millisecond(0).toISOString();
         }
       }
 

--- a/lib/calendar_events.rb
+++ b/lib/calendar_events.rb
@@ -33,6 +33,7 @@ class CalendarEvents::Helper
     event_start = event[:start].to_datetime
     event_end = event[:end].present? ? event[:end].to_datetime : nil
     format = event[:all_day] ? :date_only : :long
+    event_version  = event[:version] if event[:version]
 
     event_timezone = SiteSetting.events_timezone_default
     event_timezone = event[:timezone] if event[:timezone].present?
@@ -49,7 +50,8 @@ class CalendarEvents::Helper
     result = {
       start: event_start,
       end: event_end,
-      format: format
+      format: format,
+      version: event_version
     }
 
     if event_timezone.present?

--- a/lib/tasks/add_event_version.rake
+++ b/lib/tasks/add_event_version.rake
@@ -1,0 +1,12 @@
+
+desc "adds event version for using in ical feed for the event posts"
+
+task "events:add_event_version" => :environment do
+  topic_ids = TopicCustomField.where(name: 'event_start').pluck(:topic_id)
+  topic_ids = topic_ids.select { |topic_id|  TopicCustomField.where(topic_id: topic_id, name: 'event_version').empty? }
+
+  topic_ids.each do |topic_id|
+    TopicCustomField.new(topic_id: topic_id, name: 'event_version',value: 1).save
+    puts "event_version for topic id #{topic_id} saved successfully"
+  end
+end

--- a/plugin.rb
+++ b/plugin.rb
@@ -524,12 +524,12 @@ after_initialize do
       list_opts = {}
       list_opts[:category] = @category.id if @category
       list_opts[:tags] = params[:tags] if params[:tags]
-      
+
       if current_user &&
          SiteSetting.respond_to?(:assign_enabled) &&
          SiteSetting.assign_enabled
         list_opts[:assigned] = current_user.username if params[:assigned]
-      end 
+      end
 
       tzid = params[:time_zone]
       tz = TZInfo::Timezone.get tzid
@@ -563,6 +563,7 @@ after_initialize do
             e.summary = t.title
             e.description = t.url << "\n\n" << t.excerpt #add url to event body
             e.url = t.url #most calendar clients don't display this field
+            e.uid = t.id.to_s + "@" + SiteSetting.notification_email.split('@')[1]
           end
         end
       end

--- a/plugin.rb
+++ b/plugin.rb
@@ -571,7 +571,7 @@ after_initialize do
             e.summary = t.title
             e.description = t.url << "\n\n" << t.excerpt #add url to event body
             e.url = t.url #most calendar clients don't display this field
-            e.uid = t.id.to_s + "@" + SiteSetting.notification_email.split('@')[1]
+            e.uid = t.id.to_s + "@" + Discourse.base_url.sub(/^https?\:\/\/(www.)?/,'')
             e.sequence = event[:version]
           end
         end

--- a/plugin.rb
+++ b/plugin.rb
@@ -137,6 +137,7 @@ after_initialize do
   Topic.register_custom_field_type('event_all_day', :boolean)
   Topic.register_custom_field_type('event_rsvp', :boolean)
   Topic.register_custom_field_type('event_going_max', :integer)
+  Topic.register_custom_field_type('event_version', :integer)
 
   TopicList.preloaded_custom_fields << 'event_start' if TopicList.respond_to? :preloaded_custom_fields
   TopicList.preloaded_custom_fields << 'event_end' if TopicList.respond_to? :preloaded_custom_fields
@@ -145,6 +146,7 @@ after_initialize do
   TopicList.preloaded_custom_fields << 'event_rsvp' if TopicList.respond_to? :preloaded_custom_fields
   TopicList.preloaded_custom_fields << 'event_going' if TopicList.respond_to? :preloaded_custom_fields
   TopicList.preloaded_custom_fields << 'event_going_max' if TopicList.respond_to? :preloaded_custom_fields
+  TopicList.preloaded_custom_fields << 'event_version' if TopicList.respond_to? :preloaded_custom_fields
 
   load File.expand_path('../lib/calendar_events.rb', __FILE__)
   load File.expand_path('../controllers/event_rsvp.rb', __FILE__)
@@ -184,6 +186,10 @@ after_initialize do
 
         if event_going
           event[:going] = event_going
+        end
+
+        if custom_fields['event_version'].present?
+          event[:version] = custom_fields['event_version']
         end
       end
 
@@ -270,43 +276,43 @@ after_initialize do
     ],
   )
 
-  PostRevisor.track_topic_field(:event)
-
-  PostRevisor.class_eval do
-    track_topic_field(:event) do |tc, event|
+  ::PostRevisor.track_topic_field(:event) do |tc, event|
       if tc.guardian.can_edit_event?(tc.topic.category)
         event_start = event['start'] ? event['start'].to_datetime.to_i : nil
-        tc.record_change('event_start', tc.topic.custom_fields['event_start'], event_start)
-        tc.topic.custom_fields['event_start'] = event_start
+        start_change = tc.record_change('event_start', tc.topic.custom_fields['event_start'], event_start)
+        tc.topic.custom_fields['event_start'] = event_start if start_change
 
         event_end = event['end'] ? event['end'].to_datetime.to_i : nil
-        tc.record_change('event_end', tc.topic.custom_fields['event_end'], event_end)
-        tc.topic.custom_fields['event_end'] = event_end
+        end_change = tc.record_change('event_end', tc.topic.custom_fields['event_end'], event_end)
+        tc.topic.custom_fields['event_end'] = event_end  if end_change
 
         all_day = event['all_day'] ? event['all_day'] === 'true' : false
-        tc.record_change('event_all_day', tc.topic.custom_fields['event_all_day'], all_day)
-        tc.topic.custom_fields['event_all_day'] = all_day
+        all_day_change = tc.record_change('event_all_day', tc.topic.custom_fields['event_all_day'], all_day)
+        tc.topic.custom_fields['event_all_day'] = all_day if all_day_change
 
         timezone = event['timezone']
-        tc.record_change('event_timezone', tc.topic.custom_fields['event_timezone'], timezone)
-        tc.topic.custom_fields['event_timezone'] = timezone
+        timezone_change = tc.record_change('event_timezone', tc.topic.custom_fields['event_timezone'], timezone)
+        tc.topic.custom_fields['event_timezone'] = timezone if timezone_change
 
         rsvp = event['rsvp'] ? event['rsvp'] === 'true' : false
-        tc.record_change('event_rsvp', tc.topic.custom_fields['event_rsvp'], rsvp)
-        tc.topic.custom_fields['event_rsvp'] = rsvp
+        rsvp_change = tc.record_change('event_rsvp', tc.topic.custom_fields['event_rsvp'], rsvp)
+        tc.topic.custom_fields['event_rsvp'] = rsvp if rsvp_change
 
         if rsvp
           going_max = event['going_max'] ? event['going_max'].to_i : nil
-          tc.record_change('event_going_max', tc.topic.custom_fields['event_going_max'], going_max)
-          tc.topic.custom_fields['event_going_max'] = going_max
+          going_max_change = tc.record_change('event_going_max', tc.topic.custom_fields['event_going_max'], going_max)
+          tc.topic.custom_fields['event_going_max'] = going_max if going_max_change
 
           going = event['going'] ? event['going'].join(',') : ''
-          tc.record_change('event_going', tc.topic.custom_fields['event_going'], going)
-          tc.topic.custom_fields['event_going'] = going
+          going_change = tc.record_change('event_going', tc.topic.custom_fields['event_going'], going)
+          tc.topic.custom_fields['event_going'] = going if going_change
+        end
+
+        if start_change || end_change || timezone_change # increment by 1, even if more than one props are changed at once
+          tc.topic.custom_fields['event_version'] = tc.topic.custom_fields['event_version'].nil? ? 1 : tc.topic.custom_fields['event_version'] + 1
         end
       end
     end
-  end
 
   DiscourseEvent.on(:post_created) do |post, opts, user|
     if post.is_first_post? && opts[:event]
@@ -323,6 +329,7 @@ after_initialize do
       rsvp = event['rsvp']
       going_max = event['going_max']
       going = event['going']
+      event_version = 1
 
       topic.custom_fields['event_start'] = event_start.to_datetime.to_i if event_start
       topic.custom_fields['event_end'] = event_end.to_datetime.to_i if event_end
@@ -331,6 +338,7 @@ after_initialize do
       topic.custom_fields['event_rsvp'] = rsvp if rsvp
       topic.custom_fields['event_going_max'] = going_max if going_max
       topic.custom_fields['event_going'] = going if going
+      topic.custom_fields['event_version'] = event_version if event_version
 
       topic.save_custom_fields(true)
     end
@@ -564,6 +572,7 @@ after_initialize do
             e.description = t.url << "\n\n" << t.excerpt #add url to event body
             e.url = t.url #most calendar clients don't display this field
             e.uid = t.id.to_s + "@" + SiteSetting.notification_email.split('@')[1]
+            e.sequence = event[:version]
           end
         end
       end

--- a/plugin.rb
+++ b/plugin.rb
@@ -177,6 +177,10 @@ after_initialize do
         event[:all_day] = custom_fields['event_all_day']
       end
 
+      if custom_fields['event_version'].present?
+        event[:version] = custom_fields['event_version']
+      end
+
       if event_rsvp
         event[:rsvp] = event_rsvp
 
@@ -186,10 +190,6 @@ after_initialize do
 
         if event_going
           event[:going] = event_going
-        end
-
-        if custom_fields['event_version'].present?
-          event[:version] = custom_fields['event_version']
         end
       end
 


### PR DESCRIPTION
This fixes #51 

Although, It doesn't add event_version to existing posts. My suggestion is to create a rake task, which goes through all the event posts and adds a `event_version` field if it doesn't exist already.