### PR TITLE
Fix rsvp name issue

### DIFF
--- a/assets/javascripts/discourse/components/event-rsvp.js.es6
+++ b/assets/javascripts/discourse/components/event-rsvp.js.es6
@@ -66,9 +66,9 @@ export default Ember.Component.extend({
     let list = existing ? existing : [];
 
     if (action === 'add') {
-      list.push(user_id);
+      list.push(user_id.toString());
     } else {
-      list.splice(list.indexOf(user_id), 1);
+      list.splice(list.indexOf(user_id.toString()), 1);
     }
 
     this.set(`topic.event_${type}`, list);

--- a/assets/javascripts/discourse/components/event-rsvp.js.es6
+++ b/assets/javascripts/discourse/components/event-rsvp.js.es6
@@ -9,7 +9,7 @@ export default Ember.Component.extend({
 
   @computed('currentUser', 'topic.event_going')
   userGoing(user, eventGoing) {
-    return eventGoing && eventGoing.indexOf(user.username) > -1;
+    return eventGoing && eventGoing.indexOf(user.id.toString()) > -1;
   },
 
   @computed('topic.event_going')
@@ -23,13 +23,7 @@ export default Ember.Component.extend({
 
   @computed('userGoing')
   goingClasses(userGoing) {
-    let classes = '';
-
-    if (userGoing) {
-      classes += 'btn-primary';
-    }
-
-    return classes;
+    return userGoing ? 'btn-primary' : '';
   },
 
   @computed('currentUser', 'eventFull')
@@ -67,14 +61,14 @@ export default Ember.Component.extend({
     return false;
   },
 
-  updateTopic(username, action, type) {
+  updateTopic(user_id, action, type) {
     let existing = this.get(`topic.event_${type}`);
     let list = existing ? existing : [];
 
     if (action === 'add') {
-      list.push(username);
+      list.push(user_id);
     } else {
-      list.splice(list.indexOf(username), 1);
+      list.splice(list.indexOf(user_id), 1);
     }
 
     this.set(`topic.event_${type}`, list);
@@ -89,15 +83,15 @@ export default Ember.Component.extend({
       data: {
         topic_id: this.get('topic.id'),
         type,
-        username: user.username
+        user_id: user.id
       }
     }).then((result) => {
       if (result.success) {
-        this.updateTopic(user.username, action, type);
+        this.updateTopic(user.id, action, type);
       }
     }).catch(popupAjaxError).finally(() => {
       this.set(`${type}Saving`, false);
-    })
+    });
   },
 
   actions: {

--- a/assets/javascripts/discourse/components/event-rsvp.js.es6
+++ b/assets/javascripts/discourse/components/event-rsvp.js.es6
@@ -9,7 +9,7 @@ export default Ember.Component.extend({
 
   @computed('currentUser', 'topic.event_going')
   userGoing(user, eventGoing) {
-    return eventGoing && eventGoing.indexOf(user.id.toString()) > -1;
+    return eventGoing && eventGoing.indexOf(user.id) > -1;
   },
 
   @computed('topic.event_going')
@@ -61,14 +61,14 @@ export default Ember.Component.extend({
     return false;
   },
 
-  updateTopic(user_id, action, type) {
+  updateTopic(userId, action, type) {
     let existing = this.get(`topic.event_${type}`);
     let list = existing ? existing : [];
 
     if (action === 'add') {
-      list.push(user_id.toString());
+      list.push(userId);
     } else {
-      list.splice(list.indexOf(user_id.toString()), 1);
+      list.splice(list.indexOf(userId), 1);
     }
 
     this.set(`topic.event_${type}`, list);

--- a/assets/javascripts/discourse/controllers/event-rsvp.js.es6
+++ b/assets/javascripts/discourse/controllers/event-rsvp.js.es6
@@ -21,27 +21,18 @@ export default Ember.Controller.extend({
 
     let userList = [];
 
-    ajax('/calendar-events/rsvp/get_usernames', {
+    ajax('/calendar-events/rsvp/get_users', {
       data:{
         user_ids: user_ids
       },
       type: "POST"
     }).then((response) => {
-      let usernames = response.usernames;
-
-        usernames.forEach((username, index) => {
-        User.findByUsername(username).then((user) => {
-          userList.push(user);
-
-          if (userList.length == usernames.length) {
-            this.setProperties({
-              userList,
-              loadingList: false
-            })
-          }
-        })
-      });
-    })
+      let userList = response.users;
+        this.setProperties({
+          userList,
+          loadingList: false
+        });
+    });
   },
 
   @computed('type')

--- a/controllers/event_rsvp.rb
+++ b/controllers/event_rsvp.rb
@@ -14,7 +14,7 @@ class CalendarEvents::RsvpController < ApplicationController
 
     list.push(rsvp_params[:user_id].to_i)
 
-    @topic.custom_fields[prop] = list.to_json
+    @topic.custom_fields[prop] = list
 
     if topic.save_custom_fields(true)
       push_update(topic, prop)
@@ -32,7 +32,7 @@ class CalendarEvents::RsvpController < ApplicationController
 
     list.delete(rsvp_params[:user_id].to_i)
 
-    @topic.custom_fields[prop] = list.to_json
+    @topic.custom_fields[prop] = list
 
     if topic.save_custom_fields(true)
       push_update(topic, prop)

--- a/controllers/event_rsvp.rb
+++ b/controllers/event_rsvp.rb
@@ -12,9 +12,9 @@ class CalendarEvents::RsvpController < ApplicationController
       raise I18n.t('event_rsvp.errors.going_max')
     end
 
-    list.push(rsvp_params[:user_id])
+    list.push(rsvp_params[:user_id].to_i)
 
-    @topic.custom_fields[prop] = list.join(',')
+    @topic.custom_fields[prop] = list.to_json
 
     if topic.save_custom_fields(true)
       push_update(topic, prop)
@@ -30,9 +30,9 @@ class CalendarEvents::RsvpController < ApplicationController
 
     list = @topic.send(prop) || []
 
-    list.delete(rsvp_params[:user_id])
+    list.delete(rsvp_params[:user_id].to_i)
 
-    @topic.custom_fields[prop] = list.join(',')
+    @topic.custom_fields[prop] = list.to_json
 
     if topic.save_custom_fields(true)
       push_update(topic, prop)
@@ -44,9 +44,12 @@ class CalendarEvents::RsvpController < ApplicationController
   end
 
   def get_users
-    users = User.find(rsvp_params[:user_ids])
-    serializer = ::ActiveModel::ArraySerializer.new(users, each_serializer: BasicUserSerializer)
-    render json: success_json.merge(users: serializer)
+    begin
+      users = User.find(rsvp_params[:user_ids])
+      render_json_dump(success_json.merge(users: serialize_data(users, BasicUserSerializer)))
+    rescue
+      render_json_dump "[]"
+    end
   end
 
   private

--- a/controllers/event_rsvp.rb
+++ b/controllers/event_rsvp.rb
@@ -1,7 +1,7 @@
 class CalendarEvents::RsvpController < ApplicationController
   attr_accessor :topic
   before_action :check_user_and_find_topic, only: [:add, :remove]
-  before_action :check_if_rsvp_enabled, except: [:get_usernames]
+  before_action :check_if_rsvp_enabled, except: [:get_users]
 
   def add
     prop = "event_#{rsvp_params[:type]}".freeze
@@ -43,8 +43,10 @@ class CalendarEvents::RsvpController < ApplicationController
     end
   end
 
-  def get_usernames
-    render json: success_json.merge(usernames: User.find(rsvp_params[:user_ids]).pluck(:username))
+  def get_users
+    users = User.find(rsvp_params[:user_ids])
+    serializer = ::ActiveModel::ArraySerializer.new(users, each_serializer: BasicUserSerializer)
+    render json: success_json.merge(users: serializer)
   end
 
   private

--- a/controllers/event_rsvp.rb
+++ b/controllers/event_rsvp.rb
@@ -1,7 +1,7 @@
 class CalendarEvents::RsvpController < ApplicationController
   attr_accessor :topic
   before_action :check_user_and_find_topic, only: [:add, :remove]
-  before_action :check_if_rsvp_enabled, except: [:get_users]
+  before_action :check_if_rsvp_enabled, except: [:users]
 
   def add
     prop = "event_#{rsvp_params[:type]}".freeze
@@ -44,11 +44,15 @@ class CalendarEvents::RsvpController < ApplicationController
   end
 
   def users
-    begin
-      users = User.find(rsvp_params[:user_ids])
-      render_json_dump(success_json.merge(users: serialize_data(users, BasicUserSerializer)))
-    rescue
+    unless rsvp_params[:user_ids].any?
       render_json_dump "[]"
+    else
+      begin
+        users = User.find(rsvp_params[:user_ids])
+        render_json_dump(success_json.merge(users: serialize_data(users, BasicUserSerializer)))
+      rescue
+        render_json_dump "[]"
+      end
     end
   end
 

--- a/controllers/event_rsvp.rb
+++ b/controllers/event_rsvp.rb
@@ -43,7 +43,7 @@ class CalendarEvents::RsvpController < ApplicationController
     end
   end
 
-  def get_users
+  def users
     begin
       users = User.find(rsvp_params[:user_ids])
       render_json_dump(success_json.merge(users: serialize_data(users, BasicUserSerializer)))

--- a/db/migrate/20191016154136_rsvp_migration.rb
+++ b/db/migrate/20191016154136_rsvp_migration.rb
@@ -1,0 +1,25 @@
+class RsvpMigration < ActiveRecord::Migration[6.0]
+  def change
+    custom_fields = TopicCustomField.where(name: 'event_going')
+    custom_fields.each do |custom_field|
+      going = custom_field.value.split ','
+      next if going.empty?
+      going_ids = []
+
+      going.each do |v|
+        next if v.empty? || v.to_i != 0 #its an integer in quotes so its either an event created using latest code or already migrated
+        begin
+          user_id = User.find_by(username: v).id
+        rescue ActiveRecord::RecordNotFound => e
+          print "invalid username #{v}" #safely ignored invalid user id
+        else
+          going_ids.push user_id
+        end
+      end
+
+      custom_field.value = going_ids.join ","
+      custom_field.save
+      puts "RSVP for topic: #{custom_field.topic_id} migrated successfully"
+    end
+  end
+end

--- a/db/migrate/20191016154136_rsvp_migration.rb
+++ b/db/migrate/20191016154136_rsvp_migration.rb
@@ -17,7 +17,7 @@ class RsvpMigration < ActiveRecord::Migration[6.0]
         end
       end
 
-      custom_field.value = going_ids.join ","
+      custom_field.value = going_ids.to_json
       custom_field.save
       puts "RSVP for topic: #{custom_field.topic_id} migrated successfully"
     end

--- a/lib/calendar_events.rb
+++ b/lib/calendar_events.rb
@@ -11,7 +11,7 @@ CalendarEvents::Engine.routes.draw do
   post '/rsvp/add' => 'rsvp#add'
   post '/rsvp/remove' => 'rsvp#remove'
   get '/api_keys' => 'api_keys#index'
-  post '/rsvp/get_usernames' => 'rsvp#get_usernames'
+  post '/rsvp/get_users' => 'rsvp#get_users'
 end
 
 class CalendarEvents::List

--- a/lib/calendar_events.rb
+++ b/lib/calendar_events.rb
@@ -11,6 +11,7 @@ CalendarEvents::Engine.routes.draw do
   post '/rsvp/add' => 'rsvp#add'
   post '/rsvp/remove' => 'rsvp#remove'
   get '/api_keys' => 'api_keys#index'
+  post '/rsvp/get_usernames' => 'rsvp#get_usernames'
 end
 
 class CalendarEvents::List

--- a/lib/calendar_events.rb
+++ b/lib/calendar_events.rb
@@ -11,7 +11,7 @@ CalendarEvents::Engine.routes.draw do
   post '/rsvp/add' => 'rsvp#add'
   post '/rsvp/remove' => 'rsvp#remove'
   get '/api_keys' => 'api_keys#index'
-  get '/rsvp/users' => 'rsvp#get_users'
+  get '/rsvp/users' => 'rsvp#users'
 end
 
 class CalendarEvents::List

--- a/lib/calendar_events.rb
+++ b/lib/calendar_events.rb
@@ -11,7 +11,7 @@ CalendarEvents::Engine.routes.draw do
   post '/rsvp/add' => 'rsvp#add'
   post '/rsvp/remove' => 'rsvp#remove'
   get '/api_keys' => 'api_keys#index'
-  post '/rsvp/get_users' => 'rsvp#get_users'
+  get '/rsvp/users' => 'rsvp#get_users'
 end
 
 class CalendarEvents::List

--- a/plugin.rb
+++ b/plugin.rb
@@ -198,9 +198,13 @@ after_initialize do
 
     def event_going
       if self.custom_fields['event_going']
-        self.custom_fields['event_going'].split(',')
+        begin
+        JSON.parse (self.custom_fields['event_going'])
+        rescue
+        false
+        end
       else
-        []
+        false
       end
     end
 
@@ -255,7 +259,7 @@ after_initialize do
     end
 
     def event_going_total
-      object.event_going.length
+      object.event_going ? object.event_going.length : 0
     end
 
     def include_event_going_total?

--- a/plugin.rb
+++ b/plugin.rb
@@ -136,6 +136,7 @@ after_initialize do
   Topic.register_custom_field_type('event_end', :integer)
   Topic.register_custom_field_type('event_all_day', :boolean)
   Topic.register_custom_field_type('event_rsvp', :boolean)
+  Topic.register_custom_field_type('event_going', :json)
   Topic.register_custom_field_type('event_going_max', :integer)
   Topic.register_custom_field_type('event_version', :integer)
 
@@ -198,11 +199,7 @@ after_initialize do
 
     def event_going
       if self.custom_fields['event_going']
-        begin
-        JSON.parse (self.custom_fields['event_going'])
-        rescue
-        false
-        end
+        self.custom_fields['event_going']
       else
         false
       end


### PR DESCRIPTION
Fixes #37 

Changes the rsvp implementation to store user ids instead of user names in topic_custom_fields so it's immune to username change.

It also adds a migration to convert the rsvp data to be compatible with the new implementation.