### PR TITLE
Lodash being deprecated - remove _.merge

### DIFF
--- a/assets/javascripts/discourse/components/events-date-picker.js.es6
+++ b/assets/javascripts/discourse/components/events-date-picker.js.es6
@@ -4,6 +4,7 @@ import loadScript from "discourse/lib/load-script";
 import { calendarRange, firstDayOfWeek } from '../lib/date-utilities';
 import { next } from "@ember/runloop";
 import I18n from "I18n";
+import { deepMerge } from "discourse-common/lib/object";
 
 export default DatePicker.extend({
   layoutName: "components/date-picker",
@@ -41,7 +42,7 @@ export default DatePicker.extend({
           }
         };
 
-        this._picker = new Pikaday(_.merge(default_opts, this._opts()));
+        this._picker = new Pikaday(deepMerge(default_opts, this._opts()));
       });
     });
   }


### PR DESCRIPTION
Note: `deepMerge` has only recently been added to the `beta` and `stable` branches of core Discourse. Please ensure you are up to date before testing the change contained with this PR.