### PR TITLE
DEV: Remove 'camelize' string prototype extensions

### DIFF
--- a/assets/javascripts/discourse/connectors/category-custom-settings/enable-events.js.es6
+++ b/assets/javascripts/discourse/connectors/category-custom-settings/enable-events.js.es6
@@ -1,3 +1,5 @@
+import { camelize } from "@ember/string";
+
 export default {
   setupComponent(attrs, component) {
     if (!attrs.category.custom_fields) {
@@ -8,7 +10,7 @@ export default {
       const settings = component.siteSettings;
       const siteEnabled = settings[name];
       const categorySetting = attrs.category.custom_fields[name];
-      const property = name.camelize();
+      const property = camelize(name);
       const value = categorySetting !== undefined ? categorySetting : siteEnabled;
 
       component.set(property, value);


### PR DESCRIPTION
## Ember upgrades

Context: https://deprecations.emberjs.com/v3.x/#toc_ember-string-prototype_extensions