### PR TITLE
DEV: Replace `{{user-selector}}` with `{{email-group-user-chooser}}`

### DIFF
--- a/assets/javascripts/discourse/lib/date-utilities.js.es6
+++ b/assets/javascripts/discourse/lib/date-utilities.js.es6
@@ -260,7 +260,7 @@ function compileEvent(params) {
     }
 
     if (params.usersGoing) {
-      event.going = params.usersGoing.split(',')
+      event.going = params.usersGoing;
     }
   }
   

--- a/assets/javascripts/discourse/templates/components/event-form.hbs
+++ b/assets/javascripts/discourse/templates/components/event-form.hbs
@@ -107,8 +107,9 @@
 
         <div class="control full-width">
           <span>{{i18n 'add_event.going'}}</span>
-          {{user-selector
-            usernames=usersGoing
+          {{email-group-user-chooser
+            value=usersGoing
+            onChange=(action (mut usersGoing))
             class="user-selector"
             placeholderKey="composer.users_placeholder"}}
         </div>


### PR DESCRIPTION
`{{user-selector}}` has been deprecated since February 2021 and is about to be removed https://github.com/discourse/discourse/commit/293fd1f743b1c8165e1cd06b1169134197a231f7. `{{email-group-user-chooser}}` is the new replacement and this PR migrates the plugin to use this new component. There are no JS tests in this plugin, but I tested this change manually and the new component worked perfectly fine when adding/removing users to a new event.