### PR TITLE
Changed the retrieval of RSVP users request from GET to POST

### DIFF
--- a/assets/javascripts/discourse/controllers/event-rsvp.js.es6
+++ b/assets/javascripts/discourse/controllers/event-rsvp.js.es6
@@ -26,7 +26,8 @@ export default Controller.extend(ModalFunctionality, {
     ajax('/calendar-events/rsvp/users', {
       data:{
         usernames
-      }
+      },
+      type: "POST"
     }).then((response) => {
       let userList = response.users || [];
       

--- a/lib/calendar_events.rb
+++ b/lib/calendar_events.rb
@@ -12,7 +12,7 @@ CalendarEvents::Engine.routes.draw do
   post '/rsvp/add' => 'rsvp#add'
   post '/rsvp/remove' => 'rsvp#remove'
   get '/api_keys' => 'api_keys#index'
-  get '/rsvp/users' => 'rsvp#users'
+  post '/rsvp/users' => 'rsvp#users'
 end
 
 class CalendarEvents::List


### PR DESCRIPTION
This is a patch to fix an issue where there are many users RSVP to an event, and pulling a list from a GET request would surpass the limit for parameter length