### PR TITLE
DEV: Stop using the deprecated text.cookAsync function

### DIFF
--- a/.discourse-compatibility
+++ b/.discourse-compatibility
@@ -1,0 +1,1 @@
+3.2.0.beta2: c18cbeeac5a3f7ebf540cd6fc7edef48db889edd

--- a/assets/javascripts/discourse/components/events-calendar-card.js
+++ b/assets/javascripts/discourse/components/events-calendar-card.js
@@ -1,5 +1,5 @@
 import DiscourseURL from "discourse/lib/url";
-import { cookAsync } from "discourse/lib/text";
+import { cook } from "discourse/lib/text";
 import { on } from "discourse-common/utils/decorators";
 import { bind, next, scheduleOnce } from "@ember/runloop";
 import Component from "@ember/component";
@@ -13,8 +13,8 @@ export default Component.extend({
   setup() {
     const excerpt = this.get("topic.excerpt");
     const title = this.get("topic.title");
-    cookAsync(excerpt).then((cooked) => this.set("cookedExcerpt", cooked));
-    cookAsync(title).then((cooked) => this.set("cookedTitle", cooked));
+    cook(excerpt).then((cooked) => this.set("cookedExcerpt", cooked));
+    cook(title).then((cooked) => this.set("cookedTitle", cooked));
   },
 
   didInsertElement() {


### PR DESCRIPTION
The `cookAsync` functions is deprecated since https://github.com/discourse/discourse/commit/fcc9d99ba256ba323eb1ebaa8b256d759eadded7.