### PR TITLE
FIX: Migrate legacy hamburger menu links to sidebar

### DIFF
--- a/assets/javascripts/discourse/initializers/discourse-events.js
+++ b/assets/javascripts/discourse/initializers/discourse-events.js
@@ -344,23 +344,53 @@ export default {
       });
 
       if (siteSettings.events_hamburger_menu_calendar_link) {
-        api.decorateWidget("hamburger-menu:generalLinks", () => {
-          return {
-            route: "discovery.calendar",
-            className: "calendar-link",
-            label: "filters.calendar.title",
-          };
-        });
+        if (
+          api.addCommunitySectionLink &&
+          siteSettings.navigation_menu !== "legacy"
+        ) {
+          api.addCommunitySectionLink((baseSectionLink) => {
+            return class EventsCalendarSectionLink extends baseSectionLink {
+              name = "calendar-link";
+              route = "discovery.calendar";
+              text = I18n.t("filters.calendar.title");
+              title = I18n.t("filters.calendar.title");
+            };
+          });
+        } else {
+          // Remove this decoration and the if condition once Discourse 3.2.0 is released to stable
+          api.decorateWidget("hamburger-menu:generalLinks", () => {
+            return {
+              route: "discovery.calendar",
+              className: "calendar-link",
+              label: "filters.calendar.title",
+            };
+          });
+        }
       }
 
       if (siteSettings.events_hamburger_menu_agenda_link) {
-        api.decorateWidget("hamburger-menu:generalLinks", () => {
-          return {
-            route: "discovery.agenda",
-            className: "agenda-link",
-            label: "filters.agenda.title",
-          };
-        });
+        if (
+          api.addCommunitySectionLink &&
+          siteSettings.navigation_menu !== "legacy"
+        ) {
+          api.addCommunitySectionLink((baseSectionLink) => {
+            return class EventsAgendaSectionLink extends baseSectionLink {
+              name = "agenda-link";
+              route = "discovery.agenda";
+              text = I18n.t("filters.agenda.title");
+              title = I18n.t("filters.agenda.title");
+            };
+          });
+        } else {
+          // Remove this decoration and the if condition once Discourse 3.2.0 is released to stable
+          api.decorateWidget("hamburger-menu:generalLinks", () => {
+            return {
+              route: "discovery.agenda",
+              className: "agenda-link",
+              label: "filters.agenda.title",
+            };
+          });
+        }
       }
 
       const user = api.getCurrentUser();


### PR DESCRIPTION
The legacy hamburger menu, which is implemented using the hamburger-menu widget, is being removed from core (see https://github.com/discourse/discourse/pull/24788 and https://github.com/discourse/discourse/commit/832b3b9e60352f5cf293ea8d85a0645a6657455e), so we need to migrate all customizations that currently target the legacy hamburger menu to the new sidebar.

This PR migrates the calendar and agenda links that the plugin adds to the legacy hamburger menu to the new sidebar. The `legacy` option is still available for sites running the stable branch, so the logic for the legacy hamburger menu should be kept around until Discourse 3.2.0 is released at which the code for the legacy menu can be safely deleted.