### PR TITLE
DEV: Resolve `link-to.positional-arguments` deprecation

### DIFF
--- a/assets/javascripts/discourse/connectors/user-preferences-nav/event-ical-key.hbs
+++ b/assets/javascripts/discourse/connectors/user-preferences-nav/event-ical-key.hbs
@@ -1,5 +1,5 @@
 <li class="nav-webcal-keys">
-  {{#link-to "preferences.webcal-keys"}}
+  {{#link-to route="preferences.webcal-keys"}}
     {{i18n "webcal_preferences.webcal_keys"}}
   {{/link-to}}
 </li>


### PR DESCRIPTION
https://deprecations.emberjs.com/v3.x#toc_ember-glimmer-link-to-positional-arguments

This deprecation happens at build-time, which means it doesn't get surfaced like other deprecations in Discourse themes/plugins.